### PR TITLE
Allow settings to be set via /edx/etc/studio.yml

### DIFF
--- a/lx_pathway_plugin/apps.py
+++ b/lx_pathway_plugin/apps.py
@@ -26,7 +26,7 @@ class LxPathwayPluginAppConfig(AppConfig):
         },
         PluginSettings.CONFIG: {
             ProjectType.CMS: {
-                SettingsType.COMMON: {PluginSettings.RELATIVE_PATH: 'settings'},
+                SettingsType.PRODUCTION: {PluginSettings.RELATIVE_PATH: 'settings'},
             },
         },
     }

--- a/lx_pathway_plugin/settings.py
+++ b/lx_pathway_plugin/settings.py
@@ -6,12 +6,6 @@ integration with Open edX.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-# Declare defaults: ############################################################
-
-# The list of usernames that have permission to use this API
-# (primarily the LabXchange service user)
-LX_PATHWAY_PLUGIN_AUTHORIZED_USERNAMES = []
-
 # Register settings: ###########################################################
 
 
@@ -20,4 +14,13 @@ def plugin_settings(settings):
     Add our default settings to the edx-platform settings. Other settings files
     may override these values later, e.g. via envs/private.py.
     """
-    settings.LX_PATHWAY_PLUGIN_AUTHORIZED_USERNAMES = LX_PATHWAY_PLUGIN_AUTHORIZED_USERNAMES
+    env_tokens = getattr(settings, 'ENV_TOKENS', {})
+
+    # LX_PATHWAY_PLUGIN_AUTHORIZED_USERNAMES:
+    # The list of usernames that have permission to use this API
+    # (primarily the LabXchange service user)
+    settings.LX_PATHWAY_PLUGIN_AUTHORIZED_USERNAMES = env_tokens.get(
+        'LX_PATHWAY_PLUGIN_AUTHORIZED_USERNAMES',
+        [],
+    )
+    assert isinstance(settings.LX_PATHWAY_PLUGIN_AUTHORIZED_USERNAMES, list)


### PR DESCRIPTION
Simple fix to allow the important `LX_PATHWAY_PLUGIN_AUTHORIZED_USERNAMES` setting to be configured via `/edx/etc/studio.yml`. Without this, there was no way for ansible-based deployments to configure this via ansible variables.