### PR TITLE
Fix use of mutable defaults

### DIFF
--- a/lx_pathway_plugin/migrations/0001_initial.py
+++ b/lx_pathway_plugin/migrations/0001_initial.py
@@ -25,8 +25,8 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(primary_key=True, serialize=False)),
                 ('uuid', models.UUIDField(default=uuid.uuid4, editable=False, unique=True)),
-                ('draft_data', jsonfield.fields.JSONField(blank=True, default={})),
-                ('published_data', jsonfield.fields.JSONField(blank=True, default={})),
+                ('draft_data', jsonfield.fields.JSONField(blank=True, default=dict)),
+                ('published_data', jsonfield.fields.JSONField(blank=True, default=dict)),
                 ('owner_group', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, to='auth.Group')),
                 ('owner_user', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
             ],

--- a/lx_pathway_plugin/models.py
+++ b/lx_pathway_plugin/models.py
@@ -39,8 +39,8 @@ class Pathway(models.Model):
     # The actual pathway data (draft and published version)
     # Contains the list of items, original XBlock IDs, notes, etc.
     # The format of these *_data fields is defined and enforced by PathwayDataSerializer (see below)
-    draft_data = JSONField(null=False, blank=True, default={})
-    published_data = JSONField(null=False, blank=True, default={})
+    draft_data = JSONField(null=False, blank=True, default=dict)
+    published_data = JSONField(null=False, blank=True, default=dict)
 
     def __str__(self):
         return "<Pathway: {uuid} >".format(uuid=self.uuid)  # xss-lint: disable=python-wrap-html
@@ -154,8 +154,8 @@ class PathwayDataSerializer(serializers.Serializer):
     """
     title = serializers.CharField(default="Pathway")
     description = serializers.CharField(allow_blank=True, default="")
-    items = PathwayItemSerializer(many=True, default=[])
-    data = serializers.JSONField(default={})  # Other arbitrary data like learning objectives
+    items = PathwayItemSerializer(many=True, default=list)
+    data = serializers.JSONField(default=dict)  # Other arbitrary data like learning objectives
 
 
 class PathwaySerializer(serializers.Serializer):


### PR DESCRIPTION
Simple fix to avoid usage of mutable default values that can cause bugs.

Changes an existing migration because it's a non-SQL change.


To test:

Run `make testserver` in the `blockstore` folder on your host, then:
```
make studio-shell
make -f /edx/src/lx-pathway-plugin/Makefile validate
```

Or test via LabXchange.