### PR TITLE
Fix bug in pathway opaque key parsing

### DIFF
--- a/lx_pathway_plugin/__init__.py
+++ b/lx_pathway_plugin/__init__.py
@@ -4,6 +4,6 @@ Django plugin application for exporting LabXchange data from Open edX
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 
 default_app_config = 'lx_pathway_plugin.apps.LxPathwayPluginAppConfig'  # pylint: disable=invalid-name

--- a/lx_pathway_plugin/keys.py
+++ b/lx_pathway_plugin/keys.py
@@ -128,7 +128,7 @@ class PathwayUsageLocator(CheckFieldMixin, UsageKeyV2):
         (pathway_uuid, block_type, usage_id) = parts[0:3]
         pathway_key = PathwayLocator(uuid=pathway_uuid)
         try:
-            child_usage_id = parts[4]
+            child_usage_id = parts[3]
         except IndexError:
             child_usage_id = None
         return cls(pathway_key, block_type, usage_id, child_usage_id)

--- a/lx_pathway_plugin/pathway_context.py
+++ b/lx_pathway_plugin/pathway_context.py
@@ -96,6 +96,7 @@ class PathwayContextImpl(LearningContext):
             olx_path = "{}/{}/definition.xml".format(usage_key.block_type, usage_key.child_usage_id)
         else:
             olx_path = original_def_key.olx_path
+            assert original_usage_id.block_type == usage_key.block_type
         # Now create the BundleDefinitionLocator, which is the same as original_def_key
         # except possibly with a specific version number
         return BundleDefinitionLocator(

--- a/lx_pathway_plugin/tests/test_keys.py
+++ b/lx_pathway_plugin/tests/test_keys.py
@@ -1,0 +1,44 @@
+"""
+Test for the LabXchange pathway learning context opaque keys
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from unittest import TestCase
+
+from opaque_keys.edx.keys import LearningContextKey, UsageKey
+from six import text_type
+
+from lx_pathway_plugin.keys import PathwayLocator, PathwayUsageLocator
+
+
+class PathwayKeyTests(TestCase):
+    """
+    Test for the LabXchange pathway learning context REST API
+    """
+
+    def test_pathway_key_parsing(self):
+        """
+        Test parsing of pathway keys
+        """
+        key_str = 'lx-pathway:00000000-e4fe-47af-8ff6-123456789000'
+        key = LearningContextKey.from_string(key_str)
+        self.assertEqual(text_type(key), key_str)
+        self.assertIsInstance(key, PathwayLocator)
+
+    def test_usage_key_parsing(self):
+        """
+        Test parsing of pathway usage keys
+        """
+        parent_key = LearningContextKey.from_string('lx-pathway:00000000-e4fe-47af-8ff6-123456789000')
+        # Key of a normal top-level block in a pathway:
+        key_str = 'lx-pb:00000000-e4fe-47af-8ff6-123456789000:unit:0ff24589'
+        key = UsageKey.from_string(key_str)
+        self.assertEqual(text_type(key), key_str)
+        self.assertIsInstance(key, PathwayUsageLocator)
+        self.assertEqual(key.context_key, parent_key)
+        # Key of a child block in a pathway:
+        key_str = 'lx-pb:00000000-e4fe-47af-8ff6-123456789000:problem:0ff24589:1-2'
+        key = UsageKey.from_string(key_str)
+        self.assertEqual(text_type(key), key_str)
+        self.assertIsInstance(key, PathwayUsageLocator)
+        self.assertEqual(key.context_key, parent_key)


### PR DESCRIPTION
Fixes a stupid off-by-one bug in opaque key parsing.

To test:

Run `make studio-shell` then `make -f /edx/src/lx-pathway-plugin/Makefile validate`

The included test fails without this fix. It was an oversight on my part not to have tests for the keys :/

Or if you have a LabXchange devstack, go to http://localhost:4556/library/pathway/lx-pathway:00000000-e4fe-47af-8ff6-123456789000/items/lx-pb:00000000-e4fe-47af-8ff6-123456789000:unit:0ff24589 and try to submit an answer to the problem. It won't work properly. Then checkout this branch of the plugin, wait for the LMS to restart, and try again. Now it will work.
