### PR TITLE
Fix a couple bugs

### DIFF
--- a/lx_pathway_plugin/keys.py
+++ b/lx_pathway_plugin/keys.py
@@ -71,9 +71,8 @@ class PathwayUsageLocator(CheckFieldMixin, UsageKeyV2):
         lx-pb:3f3314f8-5f59-4215-b284-09fb578f561e:html:ec1d6c9f:child1
     """
     CANONICAL_NAMESPACE = 'lx-pb'  # "LabXchange Pathway Block"
-    KEY_FIELDS = ('pathway_key', 'block_type', 'usage_id')
+    KEY_FIELDS = ('pathway_key', 'block_type', 'usage_id', 'child_usage_id')
     __slots__ = KEY_FIELDS
-    CHECKED_INIT = False
 
     # Allow usage IDs to contain unicode characters
     USAGE_ID_REGEXP = re.compile(r'^[\w\-.]+$', flags=re.UNICODE)

--- a/lx_pathway_plugin/pathway_context.py
+++ b/lx_pathway_plugin/pathway_context.py
@@ -104,6 +104,7 @@ class PathwayContextImpl(LearningContext):
             block_type=usage_key.block_type,
             olx_path=olx_path,
             bundle_version=version if version else original_def_key.bundle_version,
+            draft_name=original_def_key.draft_name if not version else None,
         )
 
     def usage_for_child_include(self, parent_usage, parent_definition, parsed_include):

--- a/lx_pathway_plugin/tests/test_keys.py
+++ b/lx_pathway_plugin/tests/test_keys.py
@@ -36,9 +36,15 @@ class PathwayKeyTests(TestCase):
         self.assertEqual(text_type(key), key_str)
         self.assertIsInstance(key, PathwayUsageLocator)
         self.assertEqual(key.context_key, parent_key)
+        self.assertEqual(key, UsageKey.from_string(key_str))  # self equality
         # Key of a child block in a pathway:
         key_str = 'lx-pb:00000000-e4fe-47af-8ff6-123456789000:problem:0ff24589:1-2'
         key = UsageKey.from_string(key_str)
         self.assertEqual(text_type(key), key_str)
         self.assertIsInstance(key, PathwayUsageLocator)
         self.assertEqual(key.context_key, parent_key)
+        self.assertEqual(key, UsageKey.from_string(key_str))  # self equality
+        self.assertNotEqual(
+            UsageKey.from_string('lx-pb:00000000-e4fe-47af-8ff6-123456789000:unit:0ff24589'),
+            UsageKey.from_string('lx-pb:00000000-e4fe-47af-8ff6-123456789000:unit:0ff24589:1-2'),
+        )


### PR DESCRIPTION
**Bug 1**: if a user uses any of Studio's XBlock APIs to get (meta)data about an XBlock in a pathway, it is possible to get this error:

```
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/xblock/api.py", line 69, in load_block
    authorized = context_impl.can_edit_block(user, usage_key)
  File "/edx/src/lx-pathway-plugin/lx_pathway_plugin/pathway_context.py", line 39, in can_edit_block
    def_key = self.definition_for_usage(usage_key)
  File "/edx/src/lx-pathway-plugin/lx_pathway_plugin/pathway_context.py", line 106, in definition_for_usage
    bundle_version=version if version else original_def_key.bundle_version,
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/opaque_keys/edx/locator.py", line 1405, in __init__
    raise ValueError(u"Exactly one of [bundle_version, draft_name, _version_or_draft] must be specified")
ValueError: Exactly one of [bundle_version, draft_name, _version_or_draft] must be specified
2020-01-28 22:50:34,305 ERROR 3557 [django.request] [user None] exception.py:135 - Internal Server Error: /api/xblock/v2/xblocks/lx-pb:00000000-e4fe-47af-8ff6-123456789000:unit:e4a54dcb/
```

The reason is that in Studio sometimes we read bundles using a `draft_name` instead of a specific `bundle_version`.  This PR makes sure we specify the `draft_name` in cases where it's needed.

Test instructions: set up a pathway XBlock then go to http://localhost:18010/api/xblock/v2/xblocks/lx-pb:00000000-e4fe-47af-8ff6-123456789000:unit:e4a54dcb/ (but put in the ID of the pathway XBlock). Make sure it doesn't return an error.

**Bug 2 [SE-2165] [LX-1084]**: The lx_assignment XBlock's [`student_view_user_state` method](https://github.com/open-craft/labxchange-xblocks/blob/master/labxchange_xblocks/assignment_block.py#L75) was sometimes missing data for some children of the assignment block.

The easiest way to reproduce this that I found was:
* Add an assignment with lots of `problem` children to a pathway
* Go to http://localhost:18000/admin/courseware/studentmodule/ and delete any StudentModule entries related to the assignment's `problem` children (if this is a brand new pathway/assignment, there won't be any)
* Clear memcached (`make memcached-shell`, `echo flush_all > /dev/tcp/127.0.0.1/11211`)
* Restart the LMS
* View the assignment in the pathway - some problems may be showing as ungraded or missing a score.

Note that the bug wasn't 100% consistent, so reproducing it is not guaranteed. But it should be possible to reproduce before this fix and impossible afterward.