### PR TITLE
Support children with bundle links, remove version pinnning (unused) [SE-2192]

### DIFF
--- a/lx_pathway_plugin/__init__.py
+++ b/lx_pathway_plugin/__init__.py
@@ -2,6 +2,6 @@
 Django plugin application for exporting LabXchange data from Open edX
 """
 
-__version__ = '1.0.0'
+__version__ = '2.0.0'
 
 default_app_config = 'lx_pathway_plugin.apps.LxPathwayPluginAppConfig'  # pylint: disable=invalid-name


### PR DESCRIPTION
This updates the pathway plugin so that pathways can include XBlocks that use bundle links, such as the assignment XBlock. I found a way to do this while also making the code much cleaner and even somewhat more performant (reducing database queries using a per-request cache).

In order to do this, it was necessary to remove support for "freezing" pathway content at an older version, something we were no longer using anyways.

Should be completely backwards-compatible; existing pathway IDs won't change.

Test instructions:

1. Check out the latest version of https://github.com/edx/edx-platform/pull/23233 (note: this is only required to run the new tests; the code works fine on any version of edx-platform master)
2. Run the following on your devstack:

```
make studio-shell
make -f /edx/src/lx-pathway-plugin/Makefile validate
```