### PR TITLE
SE-2959: travis and trove classifiers update to support python3.8 and django 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,12 @@ language: python
 python:
   - 3.5
   - 3.6
+  - 3.8
 
 env:
   - TOXENV=django111
   - TOXENV=django20
+  - TOXENV=django30
 
 matrix:
   include:

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
+        'Framework :: Django :: 3.0',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
         'Natural Language :: English',
@@ -95,6 +96,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.8',
     ],
     entry_points={
         'cms.djangoapp': [


### PR DESCRIPTION
The plugin looks to be ready for python3.8 and django 3.0 upgrade, no changes necessary

**Testing instructions**:

1. Follow the README.md instructions for installation
2. Create virtual environments for python3.6 and python3.8 for studio (everything from here should be done inside `studio-shell`)
3. For each of the environments Install `requirements/edx/development.txt`and `django==3.0`. You'll need to upgrade `django-cors-headers` and `django-config-models` as well.
4. Follow the README.md instructions for testing

**Reviewers**
- [ ] @symbolist 
- [x] @swalladge 
