### PR TITLE
SE-3667: makes sure original usage_id is never a cloned pathway child

### DIFF
--- a/lx_pathway_plugin/models.py
+++ b/lx_pathway_plugin/models.py
@@ -124,6 +124,9 @@ class PathwayItemSerializer(serializers.Serializer):
             return str(PathwayUsageLocator(pathway_key=pathway_key, block_type=block_type, usage_id=usage_id))
 
     def validate_original_usage_id(self, obj):
+        """
+        Validates the original_usage_id field isn't from a pathway child (it should be from an original asset)
+        """
         locator = UsageKey.from_string(obj)
         if isinstance(locator, PathwayUsageLocator):
             raise serializers.ValidationError("Invalid asset key")

--- a/lx_pathway_plugin/models.py
+++ b/lx_pathway_plugin/models.py
@@ -123,6 +123,12 @@ class PathwayItemSerializer(serializers.Serializer):
             usage_id = obj["id"]
             return str(PathwayUsageLocator(pathway_key=pathway_key, block_type=block_type, usage_id=usage_id))
 
+    def validate_original_usage_id(self, obj):
+        locator = UsageKey.from_string(obj)
+        if isinstance(locator, PathwayUsageLocator):
+            raise serializers.ValidationError("Invalid asset key")
+        return obj
+
 
 class PathwayDataSerializer(serializers.Serializer):
     """

--- a/lx_pathway_plugin/tests/test_pathway_api.py
+++ b/lx_pathway_plugin/tests/test_pathway_api.py
@@ -43,6 +43,8 @@ class PathwayApiTests(APITestCase):
             description="",
             allow_public_learning=True,
             allow_public_read=True,
+            library_type='complex',
+            library_license='',
         )
         cls.problem_block1_id = library_api.create_library_block(cls.lib1.key, "problem", "p1").usage_key
         library_api.publish_changes(cls.lib1.key)
@@ -54,6 +56,8 @@ class PathwayApiTests(APITestCase):
             description="",
             allow_public_learning=True,
             allow_public_read=True,
+            library_type='complex',
+            library_license='',
         )
         cls.html_block2_id = library_api.create_library_block(cls.lib2.key, "html", "h2").usage_key
         library_api.publish_changes(cls.lib2.key)

--- a/lx_pathway_plugin/tests/test_pathway_api.py
+++ b/lx_pathway_plugin/tests/test_pathway_api.py
@@ -99,6 +99,23 @@ class PathwayApiTests(APITestCase):
             },
         }
 
+    def test_pathway_invalid_original_key(self):
+        response = self.client.post(URL_CREATE_PATHWAY, self.pathway_initial_data, format='json')
+        self.assertEqual(response.status_code, 200)
+        pathway_id = response.data["id"]
+        response = self.client.patch(
+            URL_GET_PATHWAY.format(pathway_id=pathway_id), {
+                "draft_data": {
+                    "items": [
+                        {'original_usage_id': 'lx-pb:00000000-e4fe-47af-8ff6-123456789000:unit:0ff24589'},
+                    ],
+                },
+            }, format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertTrue('Invalid asset key' in str(response.data))
+
     def test_pathway_create_other_user(self):
         """
         Verify that users without explicit authorization cannot create pathways.


### PR DESCRIPTION
Testing instructions:
- Follow readme "Installation on Devstack" instructions
- Get blockstore test up: (`make testserver` inside the blockstore project)
- Follow readme "Testing on Devstack" instructions
- Callling the /api/lx-pathways/v1/pathway/{pathway_id} endpoint with the patch method and providing the a pathway child item ID as the one to clone, should return validation errors, as we should always allow original assets to be the ones pathway children are based on (this is basically what the backend test indicates as well)

Reviewers:

- [x] @swalladge 
- [ ] @symbolist 
