### PR TITLE
Support for Django-3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ LabXchange "Pathway" Plugin for Open edX
 
 This is a django app plugin that implements "Pathways" as an Open edX learning
 context. It exposes pathway functionality via a REST API and integrates with the
-XBlock runtime and XBlock REST APIs.
+XBlock runtime and XBlock REST APIs. Django 2.2 and 3.2 are supported.
 
 A "Pathway" is a short collection of XBlocks that a student works through in a
 linear sequence.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ cd $OPENEDX_WORDIR/devstack
 make studio-shell
 make -f /edx/src/lx-pathway-plugin/Makefile validate # inside the studio shell
 
-# 4.a. On a separate terminal
+# 3.b. On a separate terminal
 cd $OPENEDX_WORKDIR/devstack
 make lms-shell
 make -f /edx/src/lx-pathway-plugin/Makefile validate # inside the lms shell

--- a/README.md
+++ b/README.md
@@ -23,9 +23,23 @@ git clone https://github.com/open-craft/lx-pathway-plugin.git
 pip install -e /edx/src/lx-pathway-plugin
 ```
 
-## Testing on Devstack
+## Testing
+
+You would need the following up and running to test the plugin:
+1. edx-platform service: lms
+2. edx-platform service: studio
 
 ```
+# Start the blockstore testserver
+
+cd blockstore
+make testserver
+
+# On a separate terminal
 make studio-shell
-make -f /edx/src/lx-pathway-plugin/Makefile validate
+make -f /edx/src/lx-pathway-plugin/Makefile validate # inside the studio shell
+
+# On a separate terminal
+make lms-shell
+make -f /edx/src/lx-pathway-plugin/Makefile validate # inside the lms shell
 ```

--- a/README.md
+++ b/README.md
@@ -25,21 +25,29 @@ pip install -e /edx/src/lx-pathway-plugin
 
 ## Testing
 
-You would need the following up and running to test the plugin:
+You would need the following up and running to test the plugin.:
 1. edx-platform service: lms
 2. edx-platform service: studio
 
-```
-# Start the blockstore testserver
+### Note
+Please follow the [guide](https://github.com/edx/devstack) to install lms and studio, if not installed.
 
-cd blockstore
+```
+# 1. Copy the above plugin into the src folder
+cp -r lx-pathway-plugin $OPENEDX_WORKDIR/src/
+
+# 2. Start the blockstore testserver
+
+cd $OPENEDX_WORKDIR/blockstore
 make testserver
 
-# On a separate terminal
+# 3.a. On a separate terminal
+cd $OPENEDX_WORDIR/devstack
 make studio-shell
 make -f /edx/src/lx-pathway-plugin/Makefile validate # inside the studio shell
 
-# On a separate terminal
+# 4.a. On a separate terminal
+cd $OPENEDX_WORKDIR/devstack
 make lms-shell
 make -f /edx/src/lx-pathway-plugin/Makefile validate # inside the lms shell
 ```

--- a/lx_pathway_plugin/__init__.py
+++ b/lx_pathway_plugin/__init__.py
@@ -2,6 +2,6 @@
 Django plugin application for exporting LabXchange data from Open edX
 """
 
-__version__ = '2.0.0'
+__version__ = '3.0.0'
 
 default_app_config = 'lx_pathway_plugin.apps.LxPathwayPluginAppConfig'  # pylint: disable=invalid-name

--- a/lx_pathway_plugin/apps.py
+++ b/lx_pathway_plugin/apps.py
@@ -3,7 +3,6 @@
 lx_pathway_plugin Django application initialization.
 """
 from django.apps import AppConfig
-
 from openedx.core.djangoapps.plugins.constants import PluginSettings, PluginURLs, ProjectType, SettingsType
 
 

--- a/lx_pathway_plugin/keys.py
+++ b/lx_pathway_plugin/keys.py
@@ -55,8 +55,8 @@ class PathwayLocator(LearningContextKey):
         uuid_str = serialized
         try:
             return cls(uuid=uuid_str)
-        except (ValueError, TypeError):
-            raise InvalidKeyError(cls, serialized)
+        except (ValueError, TypeError) as exc:
+            raise InvalidKeyError(cls, serialized) from exc
 
 
 class PathwayUsageLocator(CheckFieldMixin, UsageKeyV2):

--- a/lx_pathway_plugin/models.py
+++ b/lx_pathway_plugin/models.py
@@ -81,8 +81,8 @@ class Pathway(models.Model):
             for item in items:
                 try:
                     UsageKey.from_string(item["original_usage_id"])
-                except InvalidKeyError:
-                    raise serializers.ValidationError("Invalid item ID: {}".format(item["original_usage_id"]))
+                except InvalidKeyError as exc:
+                    raise serializers.ValidationError("Invalid item ID: {}".format(item["original_usage_id"])) from exc
                 if item.get("version") is not None:
                     raise serializers.ValidationError("Pinning the version of pathway items is no longer supported.")
                 if "usage_id" in item:

--- a/lx_pathway_plugin/pathway_context.py
+++ b/lx_pathway_plugin/pathway_context.py
@@ -5,11 +5,11 @@ import logging
 
 from edx_django_utils.cache.utils import RequestCache
 from opaque_keys.edx.keys import UsageKey
+from openedx.core.djangoapps.xblock.learning_context import LearningContext
+from openedx.core.djangoapps.xblock.learning_context.manager import get_learning_context_impl
 
 from lx_pathway_plugin.keys import PathwayLocator, PathwayUsageLocator
 from lx_pathway_plugin.models import Pathway
-from openedx.core.djangoapps.xblock.learning_context import LearningContext
-from openedx.core.djangoapps.xblock.learning_context.manager import get_learning_context_impl
 
 log = logging.getLogger(__name__)
 

--- a/lx_pathway_plugin/tests/test_pathway_api.py
+++ b/lx_pathway_plugin/tests/test_pathway_api.py
@@ -15,7 +15,7 @@ from rest_framework.test import APIClient, APITestCase
 from openedx.core.djangoapps.content_libraries import api as library_api
 from openedx.core.djangoapps.xblock import api as xblock_api
 from openedx.core.lib import blockstore_api
-from student.tests.factories import UserFactory
+from common.djangoapps.student.tests.factories import UserFactory
 
 URL_CREATE_PATHWAY = '/api/lx-pathways/v1/pathway/'
 URL_GET_PATHWAY = URL_CREATE_PATHWAY + '{pathway_id}/'
@@ -118,7 +118,7 @@ class PathwayApiTests(APITestCase):
         )
 
         self.assertEqual(response.status_code, 400)
-        self.assertTrue('Invalid asset key' in str(response.data))
+        self.assertIn('Invalid asset key', str(response.data))
 
     def test_pathway_create_other_user(self):
         """

--- a/lx_pathway_plugin/tests/test_pathway_api.py
+++ b/lx_pathway_plugin/tests/test_pathway_api.py
@@ -7,15 +7,14 @@ These tests need to be run within Studio's virtualenv:
 from copy import deepcopy
 from unittest.mock import patch
 
+from common.djangoapps.student.tests.factories import UserFactory
 from django.test import override_settings
 from opaque_keys.edx.keys import UsageKey
-from organizations.models import Organization
-from rest_framework.test import APIClient, APITestCase
-
 from openedx.core.djangoapps.content_libraries import api as library_api
 from openedx.core.djangoapps.xblock import api as xblock_api
 from openedx.core.lib import blockstore_api
-from common.djangoapps.student.tests.factories import UserFactory
+from organizations.models import Organization
+from rest_framework.test import APIClient, APITestCase
 
 URL_CREATE_PATHWAY = '/api/lx-pathways/v1/pathway/'
 URL_GET_PATHWAY = URL_CREATE_PATHWAY + '{pathway_id}/'

--- a/lx_pathway_plugin/views.py
+++ b/lx_pathway_plugin/views.py
@@ -9,6 +9,7 @@ from django.contrib.auth.models import Group
 from django.db import IntegrityError
 from django.http import Http404
 from opaque_keys import InvalidKeyError
+from openedx.core.lib.api.view_utils import view_auth_classes
 from rest_framework.decorators import api_view
 from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.response import Response
@@ -16,7 +17,6 @@ from rest_framework.views import APIView
 
 from lx_pathway_plugin.keys import PathwayLocator
 from lx_pathway_plugin.models import Pathway, PathwaySerializer
-from openedx.core.lib.api.view_utils import view_auth_classes
 
 User = get_user_model()
 

--- a/lx_pathway_plugin/views.py
+++ b/lx_pathway_plugin/views.py
@@ -140,8 +140,8 @@ def create_pathway(request):
         try:
             # To specify a group, the user must be a member of the group:
             group = groups.get(name=serializer.validated_data['owner_group_name'])
-        except Group.DoesNotExist:
-            raise ValidationError("Invalid group name. Does the group exist and are you a member?")
+        except Group.DoesNotExist as exc:
+            raise ValidationError("Invalid group name. Does the group exist and are you a member?") from exc
         kwargs['owner_group'] = group
     else:
         kwargs['owner_user'] = request.user
@@ -153,8 +153,8 @@ def create_pathway(request):
 
     try:
         pathway = Pathway.objects.create(**kwargs)
-    except IntegrityError:
-        raise ValidationError("A conflicting pathway already exists.")
+    except IntegrityError as exc:
+        raise ValidationError("A conflicting pathway already exists.") from exc
     return Response(PathwaySerializer(pathway).data)
 
 
@@ -165,5 +165,5 @@ def get_pathway_or_404(pathway_key_str):
     try:
         pathway_key = PathwayLocator.from_string(pathway_key_str)
         return Pathway.objects.get(uuid=pathway_key.uuid)
-    except (InvalidKeyError, Pathway.DoesNotExist):
-        raise Http404
+    except (InvalidKeyError, Pathway.DoesNotExist) as exc:
+        raise Http404 from exc


### PR DESCRIPTION
## Description
edX is upgrading to django 3.2 "by the end of September 2021". [https://openedx.atlassian.net/wiki/spaces/AC/pages/3073376294/Django+3.2+Upgrade+How+the+Community+Can+Help](https://openedx.atlassian.net/wiki/spaces/AC/pages/3073376294/Django+3.2+Upgrade+How+the+Community+Can+Help)

Need to ensure that lx-pathway-plugin supports django 3.2 (as requested on open edx slack).

Test with django 3.2, make a PR with any required changes.

## Supporting information
For testing, lx-pathway-plugin can only be run inside the lms or studio shell along with the blockstore testserver running.

## Testing instructions
Bring up the lms and studio shell to the django version we are testing on the PR (v3.2)
For doing that, try using the branch https://github.com/open-craft/edx-platform/tree/jill/django-3.2

Go inside the shell and run `paver install_prereqs`

Then run `make -f /edx/src/lx-pathway-plugin/Makefile validate` to run the tests


## Deadline
**1st October 2021**

## Other information
NA