### PR TITLE
LX-2502 Adds date range filters to management command export_student_module_data

### DIFF
--- a/lx_pathway_plugin/__init__.py
+++ b/lx_pathway_plugin/__init__.py
@@ -2,6 +2,6 @@
 Django plugin application for exporting LabXchange data from Open edX
 """
 
-__version__ = '3.0.1'
+__version__ = '3.0.2'
 
 default_app_config = 'lx_pathway_plugin.apps.LxPathwayPluginAppConfig'  # pylint: disable=invalid-name


### PR DESCRIPTION
Adds date range filter options to the management command added by https://github.com/open-craft/lx-pathway-plugin/pull/14.

Motivation: The script has been tested on edx stage, and it's taking to long to run, so we need to limit the results somehow.

Also bumps version to `3.0.2`

Example output: [student_module_data.csv](https://github.com/open-craft/lx-pathway-plugin/files/9099090/student_module_data.csv)

Example `--dry-run`:

```
{
  "query_block": {
    "select_id": 1,
    "cost_info": {
      "query_cost": "5.21"
    },
    "table": {
      "table_name": "courseware_studentmodule",
      "access_type": "range",
      "possible_keys": [
        "courseware_studentmodule_created_9976b4ad",
        "courseware_stats"
      ],
      "key": "courseware_studentmodule_created_9976b4ad",
      "used_key_parts": [
        "created"
      ],
      "key_length": "8",
      "rows_examined_per_scan": 3,
      "rows_produced_per_join": 1,
      "filtered": "37.57",
      "index_condition": "((`edxapp`.`courseware_studentmodule`.`created` >= '2022-06-08 00:00:00') and (`edxapp`.`courseware_studentmodule`.`created` <= '2022-06-09 00:00:00'))",
      "cost_info": {
        "read_cost": "4.98",
        "eval_cost": "0.23",
        "prefix_cost": "5.21",
        "data_read_per_join": "1K"
      },
      "used_columns": [
        "id",
        "module_type",
        "module_id",
        "course_id",
        "state",
        "grade",
        "max_grade",
        "done",
        "created",
        "modified",
        "student_id"
      ],
      "attached_condition": "((`edxapp`.`courseware_studentmodule`.`module_id` like <cache>(cast('lb:LabXchange:%' as char charset binary))) or (`edxapp`.`courseware_studentmodule`.`module_id` like <cache>(cast('lb:HarvardX:%' as char charset binary))) or (`edxapp`.`courseware_studentmodule`.`module_id` like <cache>(cast('lb:SDGAcademyX:%' as char charset binary))) or (`edxapp`.`courseware_studentmodule`.`module_id` like <cache>(cast('lx-pb:%' as char charset binary))))"
    }
  }
}
```

**Testing instructions**

1. In LabXchange, answer some problems and/or change some video speed settings to generate data in the student module table.
1. Run the management command using appropriate from/to dates, and ensure that the results returned fit within that range.

    ```
    ./manage.py lms export_student_module_data --dry-run --from-date 2022-06-08 --to-date 2022-06-09
    ./manage.py lms export_student_module_data --from-date 2022-06-08 --to-date 2022-06-09
    ```