### PR TITLE
LX-2502 Adds filters to match list of block_ids to management command export_student_module_data

### DIFF
--- a/lx_pathway_plugin/__init__.py
+++ b/lx_pathway_plugin/__init__.py
@@ -2,6 +2,6 @@
 Django plugin application for exporting LabXchange data from Open edX
 """
 
-__version__ = '3.0.2'
+__version__ = '3.0.3'
 
 default_app_config = 'lx_pathway_plugin.apps.LxPathwayPluginAppConfig'  # pylint: disable=invalid-name

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -9,5 +9,3 @@
 
 # If any requirements in addition to those installed by Open edX are needed,
 # specify them here (or in quality.in, test.in, etc.):
-
-django-cursor-pagination==0.1.5


### PR DESCRIPTION
Adds a new, required `--block-ids` argument to the management command added by https://github.com/open-craft/lx-pathway-plugin/pull/14, which provides a file or URL from which to read a list of block/module IDs to filter on.

Motivation: The script has been tested on edx stage, and it's taking to long to run, so we need to ensure our query uses one of the existing indexes on the StudentModule table.

Also bumps version to `3.0.3`

Example:

* input: https://xblock-sandbox-dev.s3.amazonaws.com/block_ids.csv
* output: [student_module_data.csv](https://github.com/open-craft/lx-pathway-plugin/files/9111252/student_module_data.csv)
* EXPLAIN:

<details><summary>`./manage.py lms export_student_module_data --block-ids https://xblock-sandbox-dev.s3.amazonaws.com/block_ids.csv --dry-run`:</summary>

```json
{
  "query_block": {
    "select_id": 1,
    "cost_info": {
      "query_cost": "38.41"
    },
    "table": {
      "table_name": "courseware_studentmodule",
      "access_type": "range",
      "possible_keys": [
        "courseware_stats"
      ],
      "key": "courseware_stats",
      "used_key_parts": [
        "module_id"
      ],
      "key_length": "767",
      "rows_examined_per_scan": 16,
      "rows_produced_per_join": 16,
      "filtered": "100.00",
      "index_condition": "(`edxapp`.`courseware_studentmodule`.`module_id` in ('lx-pb:fff41c5f-0457-4475-a996-fcaf21bb3d6c:problem:3659dda648ef9f5ecb60','lx-pb:ff89f6df-4ff2-4ce4-8742-47c3ac8fd801:problem:9e38b30f1785d6d99504','lx-pb:ff9adc87-ed6b-451b-85aa-a9a7dc529226:problem:5dab75ed8a5b71ba46c1','lx-pb:ff8405bc-2834-4605-831e-eb91dc327132:problem:3c120abd0e40681da0fc','lx-pb:ffa8b592-5138-46dd-8100-54eea79d52d5:problem:0e3b982473ddb21e5e22','lx-pb:ffd7dae5-6c79-459f-b521-027f93c92532:problem:ed07b052af7072f327c4','lx-pb:ffe1cee1-8166-4955-8910-8f9d98e684ce:problem:199b1750858088981796','lx-pb:fff3a2d0-c771-41b5-9b95-c596e4249c60:problem:d5cf0b31787abb0e0d25','lx-pb:ffc0d267-3f1d-41cd-ad93-b57e1c81ecdc:problem:79af2bfdb4c3f5d585ac','lx-pb:ffda31ed-70ea-41f6-bd18-70821693f009:problem:50a7ff2617aa0078ff3e','lx-pb:ffd5b876-c02c-4f20-9f3e-bcae56d0c6bd:problem:4ea101198d02d27804c1','lx-pb:ffea0971-f063-4ccd-938c-922af38208ac:problem:3bc24f1ba61978684c02','lx-pb:ffd5020e-8a65-4d8e-9c48-d7dd3bd06171:problem:c1c4300fc5815307a155','lx-pb:ff9d3628-e643-458d-a3af-a56122cca268:problem:64def0a656895d45d948','lx-pb:ffdc7b47-73dc-4dd3-9ec7-a3bd1c93379b:problem:64c9a0e13ec599f84022','lx-pb:ff7a9834-6252-45aa-8339-d4296eb7801c:problem:f4d11c1cf1e760377537'))",
      "cost_info": {
        "read_cost": "35.21",
        "eval_cost": "3.20",
        "prefix_cost": "38.41",
        "data_read_per_join": "26K"
      },
      "used_columns": [
        "id",
        "module_type",
        "module_id",
        "course_id",
        "state",
        "grade",
        "max_grade",
        "done",
        "created",
        "modified",
        "student_id"
      ]
    }
  }
}
```
</details>

**Testing instructions**

0. Install this branch in your LMS devstack.
1. Add this script below to your devstack `edx-platform/lms/djangoapps/courseware/management/commands/dummy_student_module_data.py`, and run it in the `lms-shell`: 

    ```
    ./manage.py lms dummy_student_module_data --num-rows 10000 > block_ids.txt
    ```

    This will take some minutes. It will generate 10,000 random rows in your StudentModule table for the user with `id=7` (usually the `verified` user), and pipe the block IDs for 5% of them that are relevant to LabXchange into `block_ids.txt`.

<details><summary>dummy_student_module_data.py</summary>

```python
import os, binascii, uuid
from random import randrange
from datetime import timedelta, datetime

from django.core.management.base import BaseCommand
from django.utils import timezone
from opaque_keys.edx.keys import UsageKey

from lms.djangoapps.courseware.models import StudentModule


FIRST_DATE = datetime(2016, 1, 1, tzinfo=timezone.get_default_timezone())
SECOND_DATE = datetime(2020, 1, 1, tzinfo=timezone.get_default_timezone())
END_DATE = timezone.now()
def random_date(start, end):
    """
    This function will return a random datetime between two datetime
    objects.
    """
    delta = end - start
    int_delta = (delta.days * 24 * 60 * 60) + delta.seconds
    random_second = randrange(int_delta)
    return start + timedelta(seconds=random_second)

block_types = [
    'html',
    'video',
    'unit',
    'sequential',
    'chapter',
    'problem',
]

class Command(BaseCommand):

    def add_arguments(self, parser):
        parser.add_argument('-n', '--num-rows',
                            default=100,
                            type=int,
                            help='number of rows to add')

    def handle(self, *args, **options):
        num_rows = options['num_rows'] or 100
        for itr in range(0, num_rows):
            random_id = binascii.b2a_hex(os.urandom(10)).decode('ascii')
            random_uuid = uuid.uuid4()
            if itr < (.95 * num_rows):
                # 95% of the rows will be edX org course blocks (non-matching), created since 2016
                block_type = block_types[randrange(len(block_types))]
                usage_key = UsageKey.from_string(f'block-v1:edX+DemoX+{random_id}+type@{block_type}+block@{random_id}')
                created = random_date(FIRST_DATE, END_DATE)
            else:
                # 5% of the rows will be lx pathway problems (matching), created since 2020
                usage_key = UsageKey.from_string(f'lx-pb:{random_uuid}:problem:{random_id}')
                created = random_date(SECOND_DATE, END_DATE)
                print(f"{usage_key}")

            sm = StudentModule.objects.create(
                module_type=usage_key.block_type,
                module_state_key=usage_key,
                course_id=usage_key.context_key,
                student_id=7,
            )
            # Manually update the created date to try to use this index
            sm.created = created
            sm.modified = created
            sm.save(update_fields=['created', 'modified'])
```
</details>

1. Run the management command updated in this PR with the `block_ids.txt` generated from the previous step:

    ```
    ./manage.py lms export_student_module_data --block-ids block_ids.txt --batch-size 200 --dry-run
    ```

    Ensure the EXPLAIN output shows that it's using [access_type="range"](https://dev.mysql.com/doc/refman/5.7/en/explain-output.html#jointype_range)
   
    ```
    ...
      "access_type": "range",
      "possible_keys": [
        "courseware_stats"
      ],
      "key": "courseware_stats",
      "used_key_parts": [
        "module_id"
      ],
    ...
    ```
    
4. Run the management command updated in this PR, and ensure that the output is generated quickly

    ```
    ./manage.py lms export_student_module_data --block-ids block_ids.txt --batch-size 200 --output output.csv
    # Fetched 500 / 500 records (batch 2 / 2)... 100%
    ```
5. To cleanup the data added in step 1, run in the `lms-shell`:

    ```
    ./manage.py lms shell
   >>> from lms.djangoapps.courseware.models import StudentModule
   >>> StudentModule.objects.filter(student_id=7).count()
   100000
   >>> StudentModule.objects.filter(student_id=7).delete()
    ```

**Author Notes & Concerns**

* The default "batch size" used here was chosen to [match the default `chunk_size` used by the `StudentModule.objects.chunked_filter`](https://github.com/openedx/edx-platform/blob/5eedf84ba846fd97d45a8c0c4dec00ea517cb9eb/lms/djangoapps/courseware/models.py#L70).
* To estimate the runtime for these query, we can estimate how many disk read seeks will be performed using the number of rows in the table: (ref [MySQL 5.7 :: Estimating Query Performance](https://dev.mysql.com/doc/refman/5.7/en/estimating-performance.html)):

    ```
    seeks = log(row_count) / log( index_block_length / 3 * 2 / (index_length + data_pointer_length) ) + 1
    
    let:
       row_count = 1Tb =~ 1,000,000,000,000
       index_block_length = 1,024 bytes
       index_length = 3 bytes (size of MEDIUMINT)
       data_pointer_length = 4
    
    seeks = log(1,000,000,000,000) / log (1,024 / 3 * 2 / (3 + 4)) + 1
    seeks = 7
    ```
    
    These `seeks` will be run once per batch. We have ~30k block IDs in production, so with a batch_size=500, we'll have 60 x 7 = 420 seeks over the full run.

FYI @symbolist