### PR TITLE
[DO NOT MERGE] refactor: for use inside the labxchange app

### DIFF
--- a/lx_pathway_plugin/apps.py
+++ b/lx_pathway_plugin/apps.py
@@ -2,42 +2,9 @@
 """
 lx_pathway_plugin Django application initialization.
 """
-from django.apps import AppConfig
-from openedx.core.djangoapps.plugins.constants import PluginSettings, PluginURLs, ProjectType, SettingsType
-
-
-class LxPathwayPluginAppConfig(AppConfig):
-    """
-    Configuration for the lx_pathway_plugin Django plugin application.
-
-    See: https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/plugins/README.rst
-    """
-
-    name = 'lx_pathway_plugin'
-    plugin_app = {
-        PluginURLs.CONFIG: {
-            ProjectType.CMS: {
-                # The namespace to provide to django's urls.include.
-                PluginURLs.NAMESPACE: 'lx_pathway_plugin',
-            },
-            ProjectType.LMS: {
-                # The namespace to provide to django's urls.include.
-                PluginURLs.NAMESPACE: 'lx_pathway_plugin',
-                # use a different set of URLs/views in the LMS
-                PluginURLs.RELATIVE_PATH: 'urls_lms',
-            },
-        },
-        PluginSettings.CONFIG: {
-            ProjectType.CMS: {
-                SettingsType.PRODUCTION: {PluginSettings.RELATIVE_PATH: 'settings'},
-            },
-            ProjectType.LMS: {
-                SettingsType.PRODUCTION: {PluginSettings.RELATIVE_PATH: 'settings'},
-            },
-        },
-    }
-
-    def ready(self):
-        """
-        Load signal handlers when the app is ready.
-        """
+try:
+    # Use the Open edX app config if we can
+    from .openedx_apps import LxPathwayPluginAppConfig
+except ModuleNotFoundError:
+    # Otherwise, fall back to the LabXchange app config
+    from .lx_apps import LxPathwayPluginAppConfig

--- a/lx_pathway_plugin/lx_apps.py
+++ b/lx_pathway_plugin/lx_apps.py
@@ -1,0 +1,14 @@
+"""
+Django application initialization for use inside the LabXchange application.
+
+Here, the lx_pathway_plugin is just a normal app, not a Django plugin.
+"""
+from django.apps import AppConfig
+
+
+class LxPathwayPluginAppConfig(AppConfig):
+    """
+    Configuration for the lx_pathway_plugin Django application.
+    """
+
+    name = 'lx_pathway_plugin'

--- a/lx_pathway_plugin/openedx_apps.py
+++ b/lx_pathway_plugin/openedx_apps.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+"""
+lx_pathway_plugin Django application initialization.
+"""
+from django.apps import AppConfig
+from openedx.core.djangoapps.plugins.constants import PluginSettings, PluginURLs, ProjectType, SettingsType
+
+
+class LxPathwayPluginAppConfig(AppConfig):
+    """
+    Configuration for the lx_pathway_plugin Django plugin application.
+
+    See: https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/plugins/README.rst
+    """
+
+    name = 'lx_pathway_plugin'
+    plugin_app = {
+        PluginURLs.CONFIG: {
+            ProjectType.CMS: {
+                # The namespace to provide to django's urls.include.
+                PluginURLs.NAMESPACE: 'lx_pathway_plugin',
+            },
+            ProjectType.LMS: {
+                # The namespace to provide to django's urls.include.
+                PluginURLs.NAMESPACE: 'lx_pathway_plugin',
+                # use a different set of URLs/views in the LMS
+                PluginURLs.RELATIVE_PATH: 'urls_lms',
+            },
+        },
+        PluginSettings.CONFIG: {
+            ProjectType.CMS: {
+                SettingsType.PRODUCTION: {PluginSettings.RELATIVE_PATH: 'settings'},
+            },
+            ProjectType.LMS: {
+                SettingsType.PRODUCTION: {PluginSettings.RELATIVE_PATH: 'settings'},
+            },
+        },
+    }
+
+    def ready(self):
+        """
+        Load signal handlers when the app is ready.
+        """

--- a/lx_pathway_plugin/pathway_context.py
+++ b/lx_pathway_plugin/pathway_context.py
@@ -5,8 +5,13 @@ import logging
 
 from edx_django_utils.cache.utils import RequestCache
 from opaque_keys.edx.keys import UsageKey
-from openedx.core.djangoapps.xblock.learning_context import LearningContext
-from openedx.core.djangoapps.xblock.learning_context.manager import get_learning_context_impl
+
+try:
+    from openedx.core.djangoapps.xblock.learning_context import LearningContext
+    from openedx.core.djangoapps.xblock.learning_context.manager import get_learning_context_impl
+except ModuleNotFoundError:
+    from labxchange.apps.blocks.learning_context import LearningContext, get_learning_context_impl
+
 
 from lx_pathway_plugin.keys import PathwayLocator, PathwayUsageLocator
 from lx_pathway_plugin.models import Pathway


### PR DESCRIPTION
* uses labxchange learning contexts where available, instead of openedx
* adds a simple AppConfig with no dependencies on open edx, so the plugin can behave like a normal app within LabXchange

Note: just created this to pass the SecureFrame integration test [Version control branch approval configurations (Github)](https://app.secureframe.com/frameworks/5b6905d5-d03d-436a-bac8-bd932e7681b9/requirements/6a03e692-1a58-41e3-aa73-b95b2e9be753/testing?table-taskOnCompanyTest-open=%7B%22page%22%3A%221%22%2C%22pageSize%22%3A%2210%22%7D&table-taskOnCompanyTest-completed=%7B%22page%22%3A%221%22%2C%22pageSize%22%3A%2210%22%7D)